### PR TITLE
37 front customer메인화면과 웨이팅 등록 화면 연결

### DIFF
--- a/src/components/RestaurantList.js
+++ b/src/components/RestaurantList.js
@@ -37,16 +37,21 @@ const RestaurantList = () => {
         <div
             key={restaurant.restaurantId}
             className="restaurant-card"
-            onClick={() => navigate(`/restaurants/${restaurant.name}`)} // 클릭 시 상세 페이지로 이동
         >
           <img src={restaurant.imageUrl} alt={restaurant.name} className="restaurant-image" />
           <div className="restaurant-info">
-            <h2 className="restaurant-name">{restaurant.name}</h2>
+            <h2 className="restaurant-name" onClick={() => navigate(`/restaurants/${restaurant.name}`)}>{restaurant.name}</h2>
             <p className="restaurant-type">{getKoreanType(restaurant.category)}</p>
             <div className="restaurant-rating">
               <span className="stars">{getStars(restaurant.rating)}</span>
               <span className="rating-value">{restaurant.rating ? restaurant.rating.toFixed(1) : 'N/A'}</span>
             </div>
+            <button
+                className="waiting-button"
+                onClick={() => navigate(`/waiting?restaurantId=${restaurant.restaurantId}`)}
+            >
+              웨이팅 등록
+            </button>
           </div>
         </div>
     ));

--- a/src/components/Waiting.js
+++ b/src/components/Waiting.js
@@ -1,9 +1,14 @@
 import React, { useState, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 import { fetchData } from '../util/api';
 import styles from '../styles/Waiting.module.css'; // CSS 모듈 import
 
 function Waiting() {
-  const [restaurantId, setRestaurantId] = useState(1);
+  const location = useLocation();
+  const queryParams = new URLSearchParams(location.search);
+  const restaurantIdFromQuery = queryParams.get('restaurantId');
+
+  const [restaurantId, setRestaurantId] = useState(restaurantIdFromQuery || -1); // 초기값을 쿼리 파라미터로 설정
   const [partySize, setPartySize] = useState(1);
   const [waitingType, setWaitingType] = useState('ONLINE');
   const [demand, setDemand] = useState('');

--- a/src/components/Waiting.js
+++ b/src/components/Waiting.js
@@ -3,17 +3,36 @@ import { useLocation } from 'react-router-dom';
 import { fetchData } from '../util/api';
 import styles from '../styles/Waiting.module.css'; // CSS 모듈 import
 
-function Waiting() {
+const Waiting = () => {
   const location = useLocation();
   const queryParams = new URLSearchParams(location.search);
   const restaurantIdFromQuery = queryParams.get('restaurantId');
 
-  const [restaurantId, setRestaurantId] = useState(restaurantIdFromQuery || -1); // 초기값을 쿼리 파라미터로 설정
+  const [restaurantId, setRestaurantId] = useState(restaurantIdFromQuery || 1); // 초기값을 쿼리 파라미터로 설정
   const [partySize, setPartySize] = useState(1);
   const [waitingType, setWaitingType] = useState('ONLINE');
   const [demand, setDemand] = useState('');
   const [message, setMessage] = useState('');
   const [waitingCount, setWaitingCount] = useState(0);
+  const [showModal, setShowModal] = useState(false); // 모달 표시 상태
+
+  // 모달 컴포넌트
+  const Modal = ({ show, onClose, children }) => {
+    if (!show) {
+      return null;
+    }
+
+    return (
+        <div className={styles.modalOverlay}>
+          <div className={styles.modal}>
+            <div className={styles.modalContent}>
+              {children}
+            </div>
+            <button className={styles.closeButton} onClick={onClose}>닫기</button>
+          </div>
+        </div>
+    );
+  };
 
   // Function to fetch waiting count
   const fetchWaitingCount = async () => {
@@ -32,7 +51,6 @@ function Waiting() {
 
   const handleSignup = async (e) => {
     e.preventDefault();
-    console.log('API Base URL:', process.env.REACT_APP_API_BASE_URL);
     try {
       const requestBody = {
         restaurantId,
@@ -50,10 +68,12 @@ function Waiting() {
         body: JSON.stringify(requestBody),
       });
       setMessage(`waiting 등록 성공: ${JSON.stringify(data)}`);
+      setShowModal(true); // 모달 표시
       // Re-fetch waiting count after successful registration
       fetchWaitingCount();
     } catch (error) {
       setMessage(`waiting 등록 실패: ${error.message}`);
+      setShowModal(true); // 모달 표시
     }
   };
 
@@ -110,7 +130,11 @@ function Waiting() {
 
           <button type="submit" className={styles.button}>등록</button>
         </form>
-        {message && <p>{message}</p>}
+        {message && (
+            <Modal show={showModal} onClose={() => setShowModal(false)}>
+              <p>{message}</p>
+            </Modal>
+        )}
       </div>
   );
 }

--- a/src/styles/Waiting.module.css
+++ b/src/styles/Waiting.module.css
@@ -98,3 +98,39 @@ button:hover {
 .radioLabel input {
   margin-right: 5px;
 }
+
+
+.modalOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.modal {
+  background: white;
+  padding: 20px;
+  border-radius: 5px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  max-width: 500px;
+  width: 100%;
+}
+
+.modalContent {
+  margin-bottom: 20px;
+}
+
+.closeButton {
+  background: #007bff;
+  color: white;
+  border: none;
+  padding: 10px 20px;
+  cursor: pointer;
+  border-radius: 5px;
+  font-size: 16px;
+}

--- a/src/styles/Waiting.module.css
+++ b/src/styles/Waiting.module.css
@@ -126,7 +126,7 @@ button:hover {
 }
 
 .closeButton {
-  background: #007bff;
+  background: #ff8800;
   color: white;
   border: none;
   padding: 10px 20px;


### PR DESCRIPTION
제목 : [💄FRONT]  customer메인화면과 웨이팅 등록 화면 연결
feat(issue 번호): #37

## 🔎 작업 내용
메인화면에 웨이팅 등록화면으로 이동하는 버튼 생성
웨이팅 성공/실패 시 모달 창으로 메시지 받도록 변경

![image](https://github.com/user-attachments/assets/35db9320-0558-416f-8428-b885dee295e6)

![image](https://github.com/user-attachments/assets/8b56230c-f7c8-4030-b2ec-dd07665fd7e9)

![image](https://github.com/user-attachments/assets/4de3a664-a2e3-43d5-b2ad-064327b66169)


## 🔗 이슈 링크
- [x] #37


resolved: #37